### PR TITLE
Fix organization name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,7 @@ begin
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix skip-changelog}
-    config.user = 'voxpupuli'
+    config.user = 'ccin2p3'
     config.project = 'modulesync_config'
     config.future_release = YAML.safe_load(File.read('moduleroot/.msync.yml.erb'))['modulesync_config_version']
   end

--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -36,7 +36,7 @@ Gemfile:
       - gem: puppet-strings
         version: '>= 2.2'
 Rakefile:
-  config.user: voxpupuli
+  config.user: ccin2p3
   puppet_strings_patterns: []
 .puppet-lint.rc:
   disabled_lint_checks:

--- a/moduleroot/Rakefile.erb
+++ b/moduleroot/Rakefile.erb
@@ -52,7 +52,7 @@ begin
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file.\nEach new release typically also includes the latest modulesync defaults.\nThese should not affect the functionality of the module."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix modulesync skip-changelog}
     config.user = '<%= @configs['config.user'] -%>'
-    config.project = metadata.metadata['name']
+    config.project = "puppet-#{metadata.metadata['name'].split('-').last}"
   end
 
   # Workaround for https://github.com/github-changelog-generator/github-changelog-generator/issues/715


### PR DESCRIPTION
While here, tune how the repository url is inferred from the metadata:
the modules are named `ccin2p3/puppet-<module>`, not
`ccin2p3/ccin2p3-<module>`.
