### PR TITLE
Tweak rubocop configuration

### DIFF
--- a/moduleroot/.rubocop.yml.erb
+++ b/moduleroot/.rubocop.yml.erb
@@ -4,3 +4,9 @@
 
 inherit_gem:
   voxpupuli-test: rubocop.yml
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/WordArray:
+  EnforcedStyle: brackets


### PR DESCRIPTION
Adjust the configuration to better match ccin2p3 conventions.

Fixes https://github.com/ccin2p3/puppet-syslog_ng/issues/24
Fixes https://github.com/ccin2p3/puppet-syslog_ng/issues/25