### PR TITLE
Rely on VoxPupuli shared workflows

### DIFF
--- a/config_defaults.yml
+++ b/config_defaults.yml
@@ -9,10 +9,10 @@
 .github/SECURITY.md:
   delete: true
 .github/workflows/ci.yml:
-  beaker_fact_matrix: {}
   excludes: []
   pidfile_workaround: false
-  timeout_minutes: 40
+  additional_packages: ''
+  acceptance_tests: true
 .travis.yml:
   delete: true
 Jenkinsfile:

--- a/moduleroot/.github/workflows/ci.yml.erb
+++ b/moduleroot/.github/workflows/ci.yml.erb
@@ -11,107 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup_matrix:
-    name: 'Setup Test Matrix'
-    runs-on: ubuntu-latest
-    timeout-minutes: <%= @configs['timeout_minutes'] %>
-    outputs:
-      puppet_unit_test_matrix: ${{ steps.get-outputs.outputs.puppet_unit_test_matrix }}
-      github_action_test_matrix: ${{ steps.get-outputs.outputs.github_action_test_matrix }}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run static validations
-        run: bundle exec rake validate lint check
-      - name: Run rake rubocop
-        run: bundle exec rake rubocop
-      - name: Setup Test Matrix
-        id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround <%= @configs['pidfile_workaround'] %>
-
-  unit:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: <%= @configs['timeout_minutes'] %>
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.puppet_unit_test_matrix)}}
-    env:
-      BUNDLE_WITHOUT: development:system_tests:release
-      PUPPET_VERSION: "~> ${{ matrix.puppet }}.0"
-    name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }})
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake parallel_spec
-<%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-
-  acceptance:
-    needs: setup_matrix
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_WITHOUT: development:test:release
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{fromJson(needs.setup_matrix.outputs.github_action_test_matrix)}}
-        <%- @configs['beaker_fact_matrix'].each do |option, values| -%>
-        <%= option %>:
-        <%- values.each do |value| -%>
-          - "<%= value %>"
-        <%- end -%>
-        <%- end -%>
-        <%- if @configs['excludes'].any? -%>
-        exclude:
-        <%- @configs['excludes'].each do |exclude| -%>
-        <%- exclude.each do |key, value| -%>
-          <%= key == exclude.first.first ? '-' : ' ' %> <%= key %>: "<%= value %>"
-        <%- end -%>
-        <%- end -%>
-        <%- end -%>
-    <%-
-      name = ['${{ matrix.puppet.name }}', '${{ matrix.setfile.name }}']
-      @configs['beaker_fact_matrix'].each_key do |option|
-        name << "#{option.tr('_', ' ').capitalize} ${{ matrix.#{option} }}"
-      end
-    -%>
-    name: <%= name.join(' - ') %>
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-      - name: Run tests
-        run: bundle exec rake beaker
-        env:
-          BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet.collection }}
-          BEAKER_setfile: ${{ matrix.setfile.value }}
-          <%- @configs['beaker_fact_matrix'].keys.each do |fact| -%>
-          BEAKER_FACTER_<%= fact.upcase %>: ${{ matrix.<%= fact %> }}
-          <%- end -%>
+  puppet:
+    name: Puppet
+<%- if @configs['acceptance_tests'] && Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
+    uses: voxpupuli/gha-puppet/.github/workflows/beaker.yml@v1
+    with:
+      pidfile_workaround: '<%= @configs['pidfile_workaround'] %>'
+<%- unless @configs['additional_packages'].empty? -%>
+      additional_packages: '<%= @configs['additional_packages'] %>'
 <%- end -%>
-
-  tests:
-    needs:
-      - unit
-      <%- if Dir[File.join(@metadata[:workdir], 'spec', 'acceptance', '**', '*_spec.rb')].any? -%>
-      - acceptance
-      <%- end -%>
-    runs-on: ubuntu-latest
-    name: Test suite
-    steps:
-      - run: echo Test suite completed
+<%- else -%>
+    uses: voxpupuli/gha-puppet/.github/workflows/basic.yml@v1
+<%- unless @configs['additional_packages'].empty? -%>
+    with:
+      additional_packages: '<%= @configs['additional_packages'] %>'
+<%- end -%>
+<%- end -%>

--- a/moduleroot/.github/workflows/release.yml.erb
+++ b/moduleroot/.github/workflows/release.yml.erb
@@ -13,22 +13,13 @@ env:
   BUNDLE_WITHOUT: development:test:system_tests
 
 jobs:
-  deploy:
-    name: 'deploy to forge'
-    runs-on: ubuntu-latest
-    if: github.repository_owner == '<%= @configs[:namespace] %>'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '2.7'
-          bundler-cache: true
-      - name: Build and Deploy
-        env:
-          # Configure secrets here:
-          #  https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets
-          BLACKSMITH_FORGE_USERNAME: '${{ secrets.PUPPET_FORGE_USERNAME }}'
-          BLACKSMITH_FORGE_API_KEY: '${{ secrets.PUPPET_FORGE_API_KEY }}'
-        run: bundle exec rake module:push
+  release:
+    name: Release
+    uses: voxpupuli/gha-puppet/.github/workflows/release.yml@v1
+    with:
+      allowed_owner: '<%= @configs[:namespace] %>'
+    secrets:
+      # Configure secrets here:
+      #  https://docs.github.com/en/actions/security-guides/encrypted-secrets
+      username: ${{ secrets.PUPPET_FORGE_USERNAME }}
+      api_key: ${{ secrets.PUPPET_FORGE_API_KEY }}

--- a/moduleroot/Gemfile.erb
+++ b/moduleroot/Gemfile.erb
@@ -35,7 +35,7 @@ end
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 
-puppetversion = ENV['PUPPET_VERSION'] || '<%= @configs['puppet_version'] %>'
+puppetversion = ENV['PUPPET_GEM_VERSION'] || '<%= @configs['puppet_version'] %>'
 gem 'puppet', puppetversion, :require => false, :groups => [:test]
 
 # vim: syntax=ruby


### PR DESCRIPTION
This boillerplate is shared by all modules, and when regression happen,
all modules need to be updated.  Using shared workflows will allow us to
benefit from VoxPupuli fixes without having to copy them manually.
